### PR TITLE
Litenetlib performance

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "LiteNetLib"]
+	path = LiteNetLib
+	url = git@github.com:RevenantX/LiteNetLib.git

--- a/Benchmarks/ubuntu-0.2.1.md
+++ b/Benchmarks/ubuntu-0.2.1.md
@@ -1,0 +1,119 @@
+## Benchmarks
+
+To reproduce the benchmarks, run `./NetCoreNetworkBenchmark -b`
+
+
+```
+OS: Ubuntu 20.04.1 LTS
+CPU: Intel® Core™ i5-3570K CPU @ 3.40GHz × 4
+Mainboard:  Gigabyte Z77X-D3H Gb LAN (Atheros)
+RAM: G.Skill 16GB (2 x 8 GB) DDR3-1600 (Part number: F3-1600C11-8GNT)
+```
+### Benchmark 1 (v 0.2.1)
+* `./NetCoreNetworkBenchmark -t PingPong -l LiteNetLib -a 127.0.0.1 -p 3333 -c 1000 -s 32 -x Random -m 1 -d 60`
+* OS: Linux 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 X64
+* Framework: .NET Core 3.1.9
+* Test: PingPong
+* Address: 127.0.0.1, Port: 3333
+* Number of clients: 1000
+* Parallel messages per client: 1
+* Message size: 32 bytes
+* Message Payload: Random
+* Defined duration: 60 seconds
+
+#### ENet
+```
+Duration: 60.008 s
+Messages sent by clients: 11,613,436
+Messages server received: 11,612,476
+Messages sent by server: 11,612,475
+Messages clients received: 11,612,436
+
+Total data: 354.38 MB
+Data throughput: 5.91 MB/s
+Message throughput: 193,515 msg/s
+Message latency: 5.168 μs
+```
+
+#### LiteNetLib
+```
+Duration: 60.092 s
+Messages sent by clients: 3,915,508
+Messages server received: 3,915,362
+Messages sent by server: 3,914,945
+Messages clients received: 3,914,508
+
+Total data: 119.46 MB
+Data throughput: 1.99 MB/s
+Message throughput: 65,142 msg/s
+Message latency: 15.351 μs
+```
+
+#### NetCoreServer
+```
+Duration: 60.005 s
+Messages sent by clients: 6,604,598
+Messages server received: 6,603,735
+Messages sent by server: 6,603,733
+Messages clients received: 6,603,617
+
+Total data: 201.53 MB
+Data throughput: 3.36 MB/s
+Message throughput: 110,051 msg/s
+Message latency: 9.087 μs
+```
+
+### Benchmark 2 (v 0.2.1)
+* `./NetCoreNetworkBenchmark -t PingPong -l NetCoreServer -a 127.0.0.1 -p 3333 -c 100 -s 32 -x Random -m 1000 -d 60`
+* OS: Linux 5.4.0-52-generic #57-Ubuntu SMP Thu Oct 15 10:57:00 UTC 2020 X64
+* Framework: .NET Core 3.1.9
+* Test: PingPong
+* Address: 127.0.0.1, Port: 3333
+* Number of clients: 100
+* Parallel messages per client: 1,000
+* Message size: 32 bytes
+* Message Payload: Random
+* Defined duration: 60 seconds
+
+#### ENet
+```
+Duration: 60.017 s
+Messages sent by clients: 129,111,780
+Messages server received: 129,011,781
+Messages sent by server: 129,011,780
+Messages clients received: 129,011,780
+
+Total data: 3937.13 MB
+Data throughput: 65.60 MB/s
+Message throughput: 2,149,574 msg/s
+Message latency: 0.465 μs
+```
+
+#### LiteNetLib
+```
+Duration: 60.012 s
+Messages sent by clients: 28,786,912
+Messages server received: 28,696,204
+Messages sent by server: 28,687,309
+Messages clients received: 28,686,912
+
+Total data: 875.46 MB
+Data throughput: 14.59 MB/s
+Message throughput: 478,019 msg/s
+Message latency: 2.092 μs
+```
+
+#### NetCoreServer
+```
+Duration: 60.591 s
+Messages sent by clients: 7,296,041
+Messages server received: 7,197,985
+Messages sent by server: 7,197,984
+Messages clients received: 7,196,543
+
+Total data: 219.62 MB
+Data throughput: 3.62 MB/s
+Message throughput: 118,773 msg/s
+Message latency: 8.419 μs
+```
+

--- a/NetCoreNetworkBenchmark.sln
+++ b/NetCoreNetworkBenchmark.sln
@@ -2,6 +2,8 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NetCoreNetworkBenchmark", "NetCoreNetworkBenchmark\NetCoreNetworkBenchmark.csproj", "{A1025393-381A-4EB0-98C7-36A0FA7A4685}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteNetLib", "LiteNetLib\LiteNetLib\LiteNetLib.csproj", "{79DF5167-DF79-489F-AAF5-2F39236ED7B6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -12,5 +14,9 @@ Global
 		{A1025393-381A-4EB0-98C7-36A0FA7A4685}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1025393-381A-4EB0-98C7-36A0FA7A4685}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1025393-381A-4EB0-98C7-36A0FA7A4685}.Release|Any CPU.Build.0 = Release|Any CPU
+		{79DF5167-DF79-489F-AAF5-2F39236ED7B6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{79DF5167-DF79-489F-AAF5-2F39236ED7B6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{79DF5167-DF79-489F-AAF5-2F39236ED7B6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{79DF5167-DF79-489F-AAF5-2F39236ED7B6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
+++ b/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
@@ -35,7 +35,7 @@ namespace NetCoreNetworkBenchmark
 		/// </summary>
 		public string Address = "127.0.0.1";
 
-		public bool PrintSteps = true;
+		public bool Verbose = true;
 
 		public string Name = "Custom";
 

--- a/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
+++ b/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
@@ -39,7 +39,7 @@ namespace NetCoreNetworkBenchmark
 
 		public string Name = "Custom";
 
-		public int NumClients = 1000;
+		public int NumClients = 100;
 		public int ParallelMessagesPerClient = 1;
 		public int MessageByteSize = 32;
 		public MessagePayload MessagePayload = MessagePayload.Ones;

--- a/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
+++ b/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
@@ -48,7 +48,7 @@ namespace NetCoreNetworkBenchmark
 		public int TickRateServer = 60;
 
 		public byte[] Message { get; private set; }
-		public int TestDurationInSeconds = 2;
+		public int TestDurationInSeconds = 10;
 
 		public BenchmarkConfiguration()
 		{

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
@@ -34,6 +34,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 			listener = new EventBasedNetListener();
 			netManager = new NetManager(listener);
 			netManager.IPv6Enabled = IPv6Mode.Disabled;
+			netManager.UnsyncedEvents = true;
 
 			IsConnected = false;
 			IsDisposed = false;
@@ -118,7 +119,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 			while (benchmarkData.Running || IsConnected)
 			{
-				netManager.PollEvents();
+				//netManager.PollEvents();
 				Thread.Sleep(tickRate);
 			}
 		}

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
@@ -33,6 +33,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 			listener = new EventBasedNetListener();
 			netManager = new NetManager(listener);
+			netManager.IPv6Enabled = IPv6Mode.Disabled;
 
 			IsConnected = false;
 			IsDisposed = false;

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
@@ -57,6 +57,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 			{
 				Send(message, DeliveryMethod.Unreliable);
 			}
+			netManager.TriggerUpdate();
 		}
 
 		public Task Disconnect()
@@ -156,6 +157,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 			{
 				Interlocked.Increment(ref benchmarkData.MessagesClientReceived);
 				Send(message, deliverymethod);
+				netManager.TriggerUpdate();
 			}
 
 			reader.Recycle();

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoClient.cs
@@ -70,13 +70,6 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 				return Task.CompletedTask;
 			}
 
-			if (peer == null)
-			{
-				Console.WriteLine($"Client {id} does not know peer even though it was connected, should not happen.");
-				IsConnected = false;
-				return Task.CompletedTask;
-			}
-
 			var clientDisconnected = Task.Factory.StartNew(() =>
 			{
 				peer.Disconnect();
@@ -126,7 +119,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 		{
 			if (disconnectInfo.Reason == DisconnectReason.Timeout && benchmarkData.Running)
 			{
-				Console.WriteLine($"Client {id} disconnected due to timeout. Probably the server is overwhelmed by the requests.");
+				Utilities.WriteVerboseLine($"Client {id} disconnected due to timeout. Probably the server is overwhelmed by the requests.");
 				Interlocked.Increment(ref benchmarkData.Errors);
 			}
 			this.peer = null;
@@ -149,7 +142,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 		{
 			if (benchmarkData.Running)
 			{
-				Console.WriteLine($"Error Client {id}: {socketerror}");
+				Utilities.WriteVerboseLine($"Error Client {id}: {socketerror}");
 				Interlocked.Increment(ref benchmarkData.Errors);
 			}
 		}

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
@@ -28,8 +28,9 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 			netManager = new NetManager(listener);
 			netManager.UpdateTime = tickRate;
 			netManager.IPv6Enabled = IPv6Mode.Disabled;
-			message = new byte[config.MessageByteSize];
+			netManager.UnsyncedEvents = true;
 
+			message = new byte[config.MessageByteSize];
 			serverThread = new Thread(this.Start);
 			serverThread.Name = "LiteNetLib Server";
 
@@ -58,7 +59,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 			while (isRunning)
 			{
-				netManager.PollEvents();
+				//netManager.PollEvents();
 				Thread.Sleep(tickRate);
 			}
 		}

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
@@ -15,7 +15,6 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 		private readonly NetManager netManager;
 		private readonly byte[] message;
 		private readonly int tickRate;
-		private bool isRunning;
 
 		public EchoServer(BenchmarkConfiguration config)
 		{
@@ -51,13 +50,11 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 		private void Start()
 		{
-			isRunning = true;
 			netManager.Start(config.Port);
 		}
 
 		public Task StopServer()
 		{
-			isRunning = false;
 			netManager.Stop();
 			var serverStopped = Task.Run(() =>
 			{

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
@@ -104,6 +104,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 				Buffer.BlockCopy(reader.RawData, reader.UserDataOffset, message, 0, reader.UserDataSize);
 				peer.Send(message, deliverymethod);
 				Interlocked.Increment(ref benchmarkData.MessagesServerSent);
+				netManager.TriggerUpdate();
 			}
 
 			reader.Recycle();

--- a/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/EchoServer.cs
@@ -27,6 +27,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 			listener = new EventBasedNetListener();
 			netManager = new NetManager(listener);
 			netManager.UpdateTime = tickRate;
+			netManager.IPv6Enabled = IPv6Mode.Disabled;
 			message = new byte[config.MessageByteSize];
 
 			serverThread = new Thread(this.Start);

--- a/NetCoreNetworkBenchmark/LiteNetLib/LiteNetLibBenchmark.cs
+++ b/NetCoreNetworkBenchmark/LiteNetLib/LiteNetLibBenchmark.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace NetCoreNetworkBenchmark.LiteNetLib
@@ -19,7 +20,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 		public Task StartServer()
 		{
-			return echoServer.StartServerThread();
+			return echoServer.StartServer();
 		}
 
 		public Task StartClients()
@@ -77,7 +78,7 @@ namespace NetCoreNetworkBenchmark.LiteNetLib
 
 		public Task StopServer()
 		{
-			return echoServer.StopServerThread();
+			return echoServer.StopServer();
 		}
 
 		public Task StopClients()

--- a/NetCoreNetworkBenchmark/NetCoreNetworkBenchmark.csproj
+++ b/NetCoreNetworkBenchmark/NetCoreNetworkBenchmark.csproj
@@ -14,9 +14,12 @@
 
     <ItemGroup>
       <PackageReference Include="ENet-CSharp" Version="2.4.3" />
-      <PackageReference Include="LiteNetLib" Version="0.9.3.2" />
       <PackageReference Include="NDesk.Options" Version="0.2.1" />
       <PackageReference Include="NetCoreServer" Version="3.0.20" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\LiteNetLib\LiteNetLib\LiteNetLib.csproj" />
     </ItemGroup>
 
 </Project>

--- a/NetCoreNetworkBenchmark/NetCoreNetworkBenchmark.csproj
+++ b/NetCoreNetworkBenchmark/NetCoreNetworkBenchmark.csproj
@@ -7,8 +7,8 @@
         <Authors>Johannes Deml</Authors>
         <Company>Johannes Deml</Company>
         <RootNamespace>DotNetCoreNetworkingBenchmark</RootNamespace>
-        <PackageVersion>0.2.0</PackageVersion>
-        <AssemblyVersion>0.2.0</AssemblyVersion>
+        <PackageVersion>0.2.1</PackageVersion>
+        <AssemblyVersion>0.2.1</AssemblyVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
     </PropertyGroup>
 
@@ -22,4 +22,21 @@
       <ProjectReference Include="..\LiteNetLib\LiteNetLib\LiteNetLib.csproj" />
     </ItemGroup>
 
+
+    <PropertyGroup>
+        <ServerGarbageCollection>true</ServerGarbageCollection>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ConcurrentGarbageCollection>false</ConcurrentGarbageCollection>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <RetainVMGarbageCollection>true</RetainVMGarbageCollection>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+      <PlatformTarget>x64</PlatformTarget>
+    </PropertyGroup>
+    
 </Project>

--- a/NetCoreNetworkBenchmark/Program.cs
+++ b/NetCoreNetworkBenchmark/Program.cs
@@ -96,13 +96,13 @@ namespace NetCoreNetworkBenchmark
 
 			try
 			{
-				Utilities.WriteStep("-> Prepare Benchmark.");
+				Utilities.WriteVerbose("-> Prepare Benchmark.");
 				PrepareBenchmark();
-				Utilities.WriteStepLine(" Done");
+				Utilities.WriteVerboseLine(" Done");
 
-				Utilities.WriteStep($"-> Run Benchmark {Config.Library}...");
+				Utilities.WriteVerbose($"-> Run Benchmark {Config.Library}...");
 				RunBenchmark();
-				Utilities.WriteStepLine(" Done");
+				Utilities.WriteVerboseLine(" Done");
 			}
 			catch (Exception e)
 			{
@@ -111,9 +111,9 @@ namespace NetCoreNetworkBenchmark
 			}
 			finally
 			{
-				Utilities.WriteStep("-> Clean up.");
+				Utilities.WriteVerbose("-> Clean up.");
 				CleanupBenchmark();
-				Utilities.WriteStepLine(" Done");
+				Utilities.WriteVerboseLine(" Done");
 				Console.Write(Config.PrintStatistics());
 			}
 		}
@@ -122,13 +122,13 @@ namespace NetCoreNetworkBenchmark
 		{
 			Config.PrepareForNewBenchmark();
 			networkBenchmark.Initialize(Config);
-			Utilities.WriteStep(".");
+			Utilities.WriteVerbose(".");
 
 			var serverTask = networkBenchmark.StartServer();
 			var clientTask = networkBenchmark.StartClients();
 			serverTask.Wait();
 			clientTask.Wait();
-			Utilities.WriteStep(".");
+			Utilities.WriteVerbose(".");
 
 			networkBenchmark.ConnectClients().Wait();
 		}
@@ -148,12 +148,12 @@ namespace NetCoreNetworkBenchmark
 			networkBenchmark.DisconnectClients().Wait();
 			networkBenchmark.StopClients().Wait();
 			networkBenchmark.DisposeClients().Wait();
-			Utilities.WriteStep(".");
+			Utilities.WriteVerbose(".");
 
 
 			networkBenchmark.StopServer().Wait();
 			networkBenchmark.DisposeServer().Wait();
-			Utilities.WriteStep(".");
+			Utilities.WriteVerbose(".");
 
 			GC.Collect();
 		}
@@ -169,7 +169,7 @@ namespace NetCoreNetworkBenchmark
 				NumClients = 1000,
 				Name = "1",
 				ParallelMessagesPerClient = 1,
-				PrintSteps = false,
+				Verbose = false,
 				TestDurationInSeconds = 60,
 				TickRateServer = 60,
 				TickRateClient = 60

--- a/NetCoreNetworkBenchmark/Utilities.cs
+++ b/NetCoreNetworkBenchmark/Utilities.cs
@@ -59,9 +59,9 @@ namespace NetCoreNetworkBenchmark
 			                          $"Allowed Range: [{minValue} , {maxValue}]", nameof(value));
 		}
 
-		public static void WriteStep(string text)
+		public static void WriteVerbose(string text)
 		{
-			if (!Program.Config.PrintSteps)
+			if (!Program.Config.Verbose)
 			{
 				return;
 			}
@@ -69,9 +69,9 @@ namespace NetCoreNetworkBenchmark
 			Console.Write(text);
 		}
 
-		public static void WriteStepLine(string text)
+		public static void WriteVerboseLine(string text)
 		{
-			if (!Program.Config.PrintSteps)
+			if (!Program.Config.Verbose)
 			{
 				return;
 			}

--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@
 
 ## Description
 
-🚧 *Early in development* 🚧
-
 Benchmark for different low level [.Net Core](https://en.wikipedia.org/wiki/.NET_Core) compatible libraries that are compatible with [Unity](https://unity3d.com), but also work as standalone console applications. The benchmark focuses on performance, latency and scalability.
 
 ### Supported Libraries
@@ -49,17 +47,17 @@ RAM: G.Skill 16GB (2 x 8 GB) DDR3-1600 (Part number: F3-1600C11-8GNT)
 
 |             | ENet            | LiteNetLib    | NetCoreServer |
 | ----------- | --------------- | ------------- | ------------- |
-| Benchmark 1 | 197,036 msg/s   | 1,768 msg/s   | 107,772 msg/s |
-| Benchmark 2 | 1,908,836 msg/s | 144,585 msg/s | 118,974 msg/s |
+| Benchmark 1 | 193,515 msg/s   | 65,142 msg/s  | 110,051 msg/s |
+| Benchmark 2 | 2,149,574 msg/s | 478,019 msg/s | 118,773 msg/s |
 
 ### Notes
 
 * Messages per second are messages that are sent from the client to the server and back.
 * Benchmark 1 runs the pingpong test with **1,000** clients, which pingpong **1 message** each with the server. Message size is 32 bytes.
 * Benchmark 2 runs the pingpong test with **100** clients, which pingpong **1,000 messages** with the server. Message size is 32 bytes.
-* LiteNetLib performs better on Windows in my tests and oftentimes has problems with running all clients correctly. 
-* ENet and NetCoreServer perform better on Linux and their benchmarks are a lot more stable.
+* The tests perform better on Linux compared to Windows 10.
 * ENet and LiteNetLib merge messages, that's why they have better results in the second benchmark. 
+* LiteNetLib opens a new thread for every client and therefore has a lot more overhead in this benchmark. That overhead vanishes in a real world application, when the server only needs to run one server networking thread.
 * To get the actual round trip time, test with one parallel message (e.g. Benchmark 1).
 
 ## Installation


### PR DESCRIPTION
Fix #5 - LiteNetLib now runs x40 times faster and a lot more stable on linux
* Remove tasks and use cutting edge LiteNetLib through a submodule.
* Use new `TriggerUpdate()` method.
* Cleanup logs
* Remove server thread, since it is not necessary for LiteNetLib
* Improve Project flags (Server GC mode) and build releases only for x64 CPUs (Has only a minor impact)