### PR TITLE
Use threads for ENet Clients

### DIFF
--- a/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
+++ b/NetCoreNetworkBenchmark/BenchmarkConfiguration.cs
@@ -27,7 +27,7 @@ namespace NetCoreNetworkBenchmark
 	{
 		public readonly BenchmarkData BenchmarkData;
 		public TestType TestType = TestType.PingPong;
-		public NetworkLibrary Library = NetworkLibrary.LiteNetLib;
+		public NetworkLibrary Library = NetworkLibrary.ENet;
 		public int Port = 3333;
 
 		/// <summary>
@@ -39,7 +39,7 @@ namespace NetCoreNetworkBenchmark
 
 		public string Name = "Custom";
 
-		public int NumClients = 100;
+		public int NumClients = 1000;
 		public int ParallelMessagesPerClient = 1;
 		public int MessageByteSize = 32;
 		public MessagePayload MessagePayload = MessagePayload.Ones;

--- a/NetCoreNetworkBenchmark/Enet/ENetBenchmark.cs
+++ b/NetCoreNetworkBenchmark/Enet/ENetBenchmark.cs
@@ -7,7 +7,7 @@ namespace NetCoreNetworkBenchmark.Enet
 	{
 		private BenchmarkConfiguration config;
 		private EchoServer echoServer;
-		private List<EchoClient> echoClients;
+		private List<EnetClient> echoClients;
 
 
 		public void Initialize(BenchmarkConfiguration config)
@@ -15,7 +15,7 @@ namespace NetCoreNetworkBenchmark.Enet
 			this.config = config;
 			ENet.Library.Initialize();
 			echoServer = new EchoServer(config);
-			echoClients = new List<EchoClient>();
+			echoClients = new List<EnetClient>();
 		}
 
 		public Task StartServer()
@@ -27,7 +27,7 @@ namespace NetCoreNetworkBenchmark.Enet
 		{
 			for (int i = 0; i < config.NumClients; i++)
 			{
-				echoClients.Add(new EchoClient(i, config));
+				echoClients.Add(new EchoClientThreaded(i, config));
 			}
 
 			return Task.CompletedTask;

--- a/NetCoreNetworkBenchmark/Enet/EchoClient.cs
+++ b/NetCoreNetworkBenchmark/Enet/EchoClient.cs
@@ -5,117 +5,28 @@ using ENet;
 
 namespace NetCoreNetworkBenchmark.Enet
 {
-	internal class EchoClient
+	internal class EchoClient : EnetClient
 	{
-		public bool IsConnected => peer.State == PeerState.Connected;
-		public bool IsDisposed { get; private set; }
-
-		private int id;
-		private readonly BenchmarkConfiguration config;
-		private readonly BenchmarkData benchmarkData;
-
-		private readonly byte[] message;
-		private readonly int tickRate;
-		private readonly Host host;
-		private readonly Address address;
-		private Peer peer;
 		private Task listenTask;
 
-		public EchoClient(int id, BenchmarkConfiguration config)
+		public EchoClient(int id, BenchmarkConfiguration config) : base(id, config)
 		{
-			this.id = id;
-			this.config = config;
-			benchmarkData = config.BenchmarkData;
-			message = config.Message;
-			tickRate = Math.Max(1000 / this.config.TickRateClient, 1);
-
-			host = new Host();
-			address = new Address();
-			address.SetHost(config.Address);
-			address.Port = (ushort) config.Port;
-			IsDisposed = false;
 		}
 
-		public void Start()
+		public override void Start()
 		{
 			listenTask = Task.Factory.StartNew(ConnectAndListen, TaskCreationOptions.LongRunning);
-			IsDisposed = false;
 		}
 
-		public void StartSendingMessages()
-		{
-			var parallelMessagesPerClient = config.ParallelMessagesPerClient;
-
-			for (int i = 0; i < parallelMessagesPerClient; i++)
-			{
-				SendUnreliable(message, 0, peer);
-			}
-		}
-
-		public void Disconnect()
-		{
-			peer.DisconnectNow(0);
-		}
-
-		public async void Dispose()
+		public override async void Dispose()
 		{
 			while (!listenTask.IsCompleted)
 			{
 				await Task.Delay(10);
 			}
 
-			listenTask.Dispose();
-			host.Flush();
-			host.Dispose();
-			IsDisposed = true;
+			base.Dispose();
 		}
 
-		private void ConnectAndListen()
-		{
-			host.Create();
-			peer = host.Connect(address, 4);
-
-			while (benchmarkData.Running)
-			{
-				host.Service(tickRate, out Event netEvent);
-
-				switch (netEvent.Type)
-				{
-					case EventType.None:
-						break;
-
-					case EventType.Connect:
-						//Console.WriteLine($"Client {_id} connected!");
-						break;
-
-					case EventType.Receive:
-						Interlocked.Increment(ref benchmarkData.MessagesClientReceived);
-						netEvent.Packet.CopyTo(message);
-						SendUnreliable(message, 0, peer);
-
-						netEvent.Packet.Dispose();
-
-						break;
-				}
-			}
-		}
-
-		private void SendReliable(byte[] data, byte channelID, Peer peer)
-		{
-			Packet packet = default(Packet);
-
-			packet.Create(data, data.Length, PacketFlags.Reliable | PacketFlags.NoAllocate); // Reliable Sequenced
-			peer.Send(channelID, ref packet);
-			Interlocked.Increment(ref benchmarkData.MessagesClientSent);
-		}
-
-		private void SendUnreliable(byte[] data, byte channelID, Peer peer)
-		{
-			Packet packet = default(Packet);
-
-			packet.Create(data, data.Length, PacketFlags.None | PacketFlags.NoAllocate); // Unreliable Sequenced
-			peer.Send(channelID, ref packet);
-			Interlocked.Increment(ref benchmarkData.MessagesClientSent);
-		}
 	}
 }

--- a/NetCoreNetworkBenchmark/Enet/EchoClientThreaded.cs
+++ b/NetCoreNetworkBenchmark/Enet/EchoClientThreaded.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using ENet;
+
+namespace NetCoreNetworkBenchmark.Enet
+{
+	internal class EchoClientThreaded : EnetClient
+	{
+
+		private readonly Thread connectAndListenThread;
+
+		public EchoClientThreaded(int id, BenchmarkConfiguration config) : base(id, config)
+		{
+			connectAndListenThread = new Thread(ConnectAndListen);
+			connectAndListenThread.Name = $"ENet Client {id}";
+			connectAndListenThread.IsBackground = true;
+		}
+
+		public override void Start()
+		{
+			connectAndListenThread.Start();
+		}
+
+		public override async void Dispose()
+		{
+			while (connectAndListenThread.IsAlive)
+			{
+				await Task.Delay(10);
+			}
+
+			base.Dispose();
+		}
+	}
+}

--- a/NetCoreNetworkBenchmark/Enet/EnetClient.cs
+++ b/NetCoreNetworkBenchmark/Enet/EnetClient.cs
@@ -1,0 +1,124 @@
+﻿// --------------------------------------------------------------------------------------------------------------------
+// <copyright file="EnetClient.cs">
+//   Copyright (c) 2020 Johannes Deml. All rights reserved.
+// </copyright>
+// <author>
+//   Johannes Deml
+//   public@deml.io
+// </author>
+// --------------------------------------------------------------------------------------------------------------------
+
+using System;
+using System.Threading;
+using ENet;
+
+namespace NetCoreNetworkBenchmark.Enet
+{
+	internal abstract class EnetClient
+	{
+		public bool IsConnected => peer.State == PeerState.Connected;
+		public bool IsDisposed { get; private set; }
+
+		private int id;
+		private readonly BenchmarkConfiguration config;
+		private readonly BenchmarkData benchmarkData;
+
+		private readonly byte[] message;
+		private readonly int tickRate;
+		private readonly Host host;
+		private readonly Address address;
+		private Peer peer;
+
+		public EnetClient(int id, BenchmarkConfiguration config)
+		{
+			this.id = id;
+			this.config = config;
+			benchmarkData = config.BenchmarkData;
+			message = config.Message;
+			tickRate = Math.Max(1000 / this.config.TickRateClient, 1);
+
+			host = new Host();
+			address = new Address();
+			address.SetHost(config.Address);
+			address.Port = (ushort) config.Port;
+			IsDisposed = false;
+		}
+
+		public abstract void Start();
+
+		public void StartSendingMessages()
+		{
+			var parallelMessagesPerClient = config.ParallelMessagesPerClient;
+
+			for (int i = 0; i < parallelMessagesPerClient; i++)
+			{
+				SendUnreliable(message, 0, peer);
+			}
+		}
+
+		public void Disconnect()
+		{
+			peer.DisconnectNow(0);
+		}
+
+		public virtual async void Dispose()
+		{
+			host.Flush();
+			host.Dispose();
+			IsDisposed = true;
+		}
+
+		protected void ConnectAndListen()
+		{
+			host.Create();
+			peer = host.Connect(address, 4);
+
+			while (benchmarkData.Running)
+			{
+				host.Service(tickRate, out Event netEvent);
+
+				switch (netEvent.Type)
+				{
+					case EventType.None:
+						break;
+
+					case EventType.Connect:
+						//Console.WriteLine($"Client {_id} connected!");
+						break;
+
+					case EventType.Receive:
+						OnReceiveMessage(netEvent);
+
+						netEvent.Packet.Dispose();
+
+						break;
+				}
+			}
+		}
+
+		protected virtual void OnReceiveMessage(Event netEvent)
+		{
+			Interlocked.Increment(ref benchmarkData.MessagesClientReceived);
+			netEvent.Packet.CopyTo(message);
+			SendUnreliable(message, 0, peer);
+		}
+
+		protected void SendReliable(byte[] data, byte channelID, Peer peer)
+		{
+			Packet packet = default(Packet);
+
+			packet.Create(data, data.Length, PacketFlags.Reliable | PacketFlags.NoAllocate); // Reliable Sequenced
+			peer.Send(channelID, ref packet);
+			Interlocked.Increment(ref benchmarkData.MessagesClientSent);
+		}
+
+		protected void SendUnreliable(byte[] data, byte channelID, Peer peer)
+		{
+			Packet packet = default(Packet);
+
+			packet.Create(data, data.Length, PacketFlags.None | PacketFlags.NoAllocate); // Unreliable Sequenced
+			peer.Send(channelID, ref packet);
+			Interlocked.Increment(ref benchmarkData.MessagesClientSent);
+		}
+	}
+}


### PR DESCRIPTION
Requested to have a fair comparison between ENet and LiteNetLib (since LNl also opens one thread for each NetManager).
Has no to only a minor impact compared to Tasks.

The task implementation is still accesible through ENetClient.cs